### PR TITLE
Set the default link color, to prevent theme overrides.

### DIFF
--- a/mixins/_typography.pcss
+++ b/mixins/_typography.pcss
@@ -234,6 +234,7 @@
  * ----------------------------------------------------------------------------- */
 
 @define-mixin anchor-default {
+	color: var(--color-text-primary);
 	border-bottom: 2px solid transparent;
 	transition: var(--transition-border-color);
 
@@ -249,6 +250,7 @@
  * ----------------------------------------------------------------------------- */
 
 @define-mixin anchor-alt {
+	color: var(--color-text-primary);
 	border-bottom: 2px solid var(--color-accent-primary);
 	transition: var(--transition-color);
 
@@ -265,6 +267,7 @@
  * ----------------------------------------------------------------------------- */
 
 @define-mixin anchor-thin {
+	color: var(--color-text-primary);
 	border-bottom: 1px solid transparent;
 	transition: var(--transition-border-color);
 


### PR DESCRIPTION
As we talked with @paulmskim on the Month view PR, the idea would be to set the default link color on the common styles directly.