### PR TITLE
Adding a workflow to perform submodule synchronization

### DIFF
--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -58,11 +58,7 @@ jobs:
           GITHUB_USER: tr1b0t
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
 
-      - name: Create temp clone directory
-        shell: bash
-        run: mkdir ${GITHUB_WORKSPACE}/clone
-
       - name: Synchronize submodules
         shell: bash
         run: |
-          cd tut && ./tut submodule-sync --branch=${{ steps.extract_branch.outputs.branch }} --tmp-dir=${GITHUB_WORKSPACE}/clone
+          cd tut && ./tut submodule-sync --branch=${{ steps.extract_branch.outputs.branch }}

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -1,0 +1,65 @@
+name: 'Submodule synchronization'
+on:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'master'
+  pull_request:
+    branches-ignore:
+      - 'main'
+      - 'master'
+jobs:
+  submodule-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract branch name from GITHUB_REF
+        shell: bash
+        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
+        id: extract_branch
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer:v1
+        env:
+          fail-fast: true
+
+      - name: Fetch tut
+        uses: actions/checkout@v2
+        with:
+          repository: 'moderntribe/tut'
+          ref: 'main'
+          path: 'tut'
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache Composer Downloads
+        uses: actions/cache@v2
+        with:
+          path: vendor/
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+
+      - name: Install tut dependencies
+        shell: bash
+        run: |
+          cd tut && composer install --no-dev --ignore-platform-reqs
+
+      - name: Create .env
+        shell: bash
+        run: |
+          cd tut && echo "GITHUB_USER=$GITHUB_USER" >> .env && echo "GITHUB_OAUTH_TOKEN=$GITHUB_OAUTH_TOKEN" >> .env
+        env:
+          GITHUB_USER: tr1b0t
+          GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
+
+      - name: Synchronize submodules
+        shell: bash
+        run: |
+          cd tut && ./tut submodule-sync --branch=${{ steps.extract_branch.outputs.branch }}
+

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create temp clone directory
         shell: bash
-        run: mkdir clone
+        run: mkdir ${GITHUB_WORKSPACE}/clone
 
       - name: Synchronize submodules
         shell: bash

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -58,8 +58,11 @@ jobs:
           GITHUB_USER: tr1b0t
           GITHUB_OAUTH_TOKEN: ${{ secrets.GH_BOT_TOKEN }}
 
+      - name: Create temp clone directory
+        shell: bash
+        run: mkdir clone
+
       - name: Synchronize submodules
         shell: bash
         run: |
-          cd tut && ./tut submodule-sync --branch=${{ steps.extract_branch.outputs.branch }}
-
+          cd tut && ./tut submodule-sync --branch=${{ steps.extract_branch.outputs.branch }} --tmp-dir=${GITHUB_WORKSPACE}/clone


### PR DESCRIPTION
This leverages the `tut submodule-sync --branch=BRANCH` command and ensures on both `push` and `pull_request` that branches are synchronized. This synchronization will replace our Jenkins job that has been failing for quite some time.

This workflow _does not_ synchronize `master` or `main` branches.

The artifact for this PR is the submodule synchronization check.

Related: https://github.com/moderntribe/tribe-common/pull/1504