### PR TITLE
Add variable for outlines for more consistent accessibility work

### DIFF
--- a/_variables-full.pcss
+++ b/_variables-full.pcss
@@ -12,5 +12,6 @@
 @import "variables/_box-shadows.pcss";
 @import "variables/_forms.pcss";
 @import "variables/_opacities.pcss";
+@import "variables/_outline.pcss";
 @import "variables/_transitions.pcss";
 @import "variables/_typography.pcss";

--- a/variables/_outline.pcss
+++ b/variables/_outline.pcss
@@ -1,8 +1,16 @@
 :root {
 	/* -----------------------------------------------------------------------------
-	 * Outlines - Active/Focus
+	 * Outlines – tokens
 	 * ----------------------------------------------------------------------------- */
 
-	--tec-outline-active-default: 2px solid var(--tec-color-border-active, #1a202c);
+	/* Base pieces. */
+	--tec-outline-width-default: 2px;
+	--tec-outline-style-default: solid;
+	--tec-outline-color-default: var(--tec-color-border-active, #1a202c);
 	--tec-outline-offset-default: 2px;
+
+	/* Composed shorthand. */
+	--tec-outline-active-default: var(--tec-outline-width-default)
+		var(--tec-outline-style-default)
+		var(--tec-outline-color-default);
 }

--- a/variables/_outline.pcss
+++ b/variables/_outline.pcss
@@ -1,0 +1,8 @@
+:root {
+	/* -----------------------------------------------------------------------------
+	 * Outlines - Active/Focus
+	 * ----------------------------------------------------------------------------- */
+
+	--tec-outline-active-default: 2px solid var(--tec-color-border-active, #1a202c);
+	--tec-outline-offset-default: 2px;
+}


### PR DESCRIPTION
This is to add a default variable for outlines to ensure consistency as we work on improving accessibility in TEC plugins. 